### PR TITLE
Sc 5987 maple sdk export xmpl types from sdk

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,8 +113,8 @@ const xmpl = {
   factory: xmplImports.XMPL__factory
 }
 
-interface Types {
-  xmplfactory: xmplImports.XMPL
+interface ContractTypes {
+  xmpl: xmplImports.XMPL
   mapleToken: mapleTokenImports.MapleToken
 }
 
@@ -139,5 +139,5 @@ export {
   stakeLocker,
   uniswapRouterV2,
   xmpl,
-  Types
+  ContractTypes
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,11 @@ const xmpl = {
   factory: xmplImports.XMPL__factory
 }
 
+interface Types {
+  xmplfactory: xmplImports.XMPL
+  mapleToken: mapleTokenImports.MapleToken
+}
+
 export {
   bPool,
   collateralLocker,
@@ -133,5 +138,6 @@ export {
   repaymentCalculator,
   stakeLocker,
   uniswapRouterV2,
-  xmpl
+  xmpl,
+  Types
 }


### PR DESCRIPTION
|       Type        |              Ticket              |
| :---------------: | :------------------------------: |
| Feature | [Link](https://app.shortcut.com/maplefinance/story/5987/maple-sdk-export-xmpl-token-types-from-sdk) |

## Problem
- Webapp requires access to contract types.

## Solution
- Export types for xMPL and MapleToken from SDK in `ContractTypes` interface.