### PR TITLE
feat: add ERC20 to ContractTypes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,7 @@ interface ContractTypes {
   xmpl: xmplImports.XMPL
   pool: poolImports.Pool
   mapleRewards: mapleRewardsImports.MplRewards
+  erc20: environmentMocksImports.MintSpecialToken
 }
 
 export {


### PR DESCRIPTION
|       Type        |              Ticket              |
| :---------------: | :------------------------------: |

## Problem

Simple as it says, just additional typings needed for webapp to use USDC, WETH, or any other ERC20 token Contracts