### PR TITLE
sc-7156-maplejs-export-mapleglobals-contract-types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,7 @@ interface ContractTypes {
   loanV3Initializer: loanV3Imports.MapleLoanInitializer
   loanV3Refinancer: loanV3Imports.Refinancer
   mapleToken: mapleTokenImports.MapleToken
+  mapleGlobals: mapleGlobalsImports.MapleGlobals,
   xmpl: xmplImports.XMPL
   pool: poolImports.Pool
   mapleRewards: mapleRewardsImports.MplRewards

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,6 @@ const loanV2 = {
 }
 
 const loanV3 = {
-  factory: loanV3Imports.MapleLoanFactory__factory,
   initializer: loanV3Imports.MapleLoanInitializer__factory,
   core: loanV3Imports.MapleLoan__factory,
   refinancer: loanV3Imports.Refinancer__factory
@@ -156,7 +155,6 @@ interface ContractTypes {
   loanV2: loanV2Imports.MapleLoan
   loanV2Factory: loanV2Imports.MapleLoanFactory
   loanV3: loanV3Imports.MapleLoan
-  loanV3Factory: loanV3Imports.MapleLoanFactory
   loanV3Initializer: loanV3Imports.MapleLoanInitializer
   loanV3Refinancer: loanV3Imports.Refinancer
   mapleToken: mapleTokenImports.MapleToken

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,6 @@ const debtLockerV2 = {
 }
 
 const debtLockerV3 = {
-  factory: debtLockerV3Imports.DebtLockerFactory__factory,
   core: debtLockerV3Imports.DebtLocker__factory,
   initializer: debtLockerV3Imports.DebtLockerInitializer__factory
 }
@@ -147,7 +146,6 @@ const addresses = {
 
 interface ContractTypes {
   debtLockerV3: debtLockerV3Imports.DebtLocker
-  debtLockerV3Factory: debtLockerV3Imports.DebtLockerFactory
   debtLockerV3Initializer: debtLockerV3Imports.DebtLockerInitializer
   debtLockerV2: debtLockerV2Imports.DebtLocker
   debtLockerV2Factory: debtLockerV2Imports.DebtLockerFactory


### PR DESCRIPTION
|       Type        |              Ticket              |
| :---------------: | :------------------------------: |
| Chore | [Link](https://app.shortcut.com/maplefinance/story/7156/maplejs-add-mapleglobals-loanv3initializer-to-sdk) |

## Problem
- `MapleGlobals` contract types currently not exported

## Solution
- Export them.

## Other notes
- Also removed redundant contracts from SDK: `LoanV3Factory` & `DebtLockerV3Factory`