### PR TITLE
Adds ABI surgery scripts to build step

### DIFF
--- a/scripts/build-typechain.js
+++ b/scripts/build-typechain.js
@@ -2,9 +2,10 @@
 // Note: if this cannot be done in js, then perhaps as a `./bin/build-typechain.sh` instead.
 const path = require('path')
 const typechain = require('typechain')
-const { readFileSync } = require('fs')
+const { readFileSync, writeFileSync } = require('fs')
 
 const artifactsOutputDir = path.join(__dirname, '../src/typechain')
+const pathDir = path.join(__dirname, `../node_modules/@maplelabs/`)
 
 const getParsedConfig = () => {
   const configPath = path.join(__dirname, '../config.json')
@@ -37,9 +38,55 @@ const generateTypechainBindings = async (config) => {
   }
 }
 
+function mergeEvents({ src, dst }) {
+  console.log(`🔀 Merging events from ${src} events into ${dst}`)
+  const srcJson = JSON.parse(readFileSync(path.join(pathDir, `${src}`)).toString())
+  const events = srcJson.filter((entry) => entry.type === 'event')
+  const dstJson = JSON.parse(readFileSync(path.join(pathDir, `${dst}`)).toString())
+  const eventIndexJson = dstJson.findIndex((el) => el.type !== 'event')
+  dstJson.splice(eventIndexJson, 0, ...events)
+  writeFileSync(path.join(pathDir, `${dst}`), JSON.stringify(dstJson, null, 2))
+}
+
+function overwriteEventParams({ files, eventName, inputs }) {
+  for (const src of files) {
+    console.log('✏️ Overwriting event params for', src)
+    const filePath = path.join(pathDir, `${src.toLowerCase()}/abis/${src}.json`)
+    const json = JSON.parse(readFileSync(filePath).toString())
+    const eventIndex = json.findIndex((el) => el.type === 'event' && el.name === eventName)
+    json[eventIndex].inputs = inputs
+    writeFileSync(filePath, JSON.stringify(json, null, 2))
+  }
+}
+
 async function buildTypechain() {
   console.log('⏳ Building Typechain...')
   const config = getParsedConfig()
+  mergeEvents({ src: 'loanV3/abis/Refinancer.json', dst: 'loanV3/abis/MapleLoan.json' })
+  overwriteEventParams({
+    files: ['Pool', 'StakeLocker'],
+    eventName: 'LossesRecognized',
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'by',
+        type: 'address'
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'lossesRecognized',
+        type: 'uint256'
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'totalLossesRecognized',
+        type: 'uint256'
+      }
+    ]
+  })
   await generateTypechainBindings(config)
 }
 


### PR DESCRIPTION
## Problem

The `maple-deploy` repo has some surgery scripts to fix the ABI for the subgraph. We need these changes reflected in the SDK so it can be used in the Subgraph as we transition away from maple-deploy

## Solution

Copy paste / fix pathing from maple-deploy

## Screenshots
Preprocess surgery, then continue with typechain:
![Screenshot 2022-07-11 at 14 06 12](https://user-images.githubusercontent.com/3671304/178271033-dd9cb350-f03e-4e78-acca-94cc5f9bd3a3.png)
Using the SDK (post surgery) in the subgraph:
![Screenshot 2022-07-11 at 14 19 09](https://user-images.githubusercontent.com/3671304/178273364-7de0993d-8d40-4804-a366-a7337bc3ba34.png)