### PR TITLE
chore: Update Pool v2 abis

### DIFF
--- a/src/abis/LoanManager.abi.json
+++ b/src/abis/LoanManager.abi.json
@@ -23,21 +23,9 @@
     "inputs": [
       {
         "indexed": false,
-        "internalType": "uint256",
-        "name": "principalOut_",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "domainStart_",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
+        "internalType": "uint48",
         "name": "domainEnd_",
-        "type": "uint256"
+        "type": "uint48"
       },
       {
         "indexed": false,
@@ -47,9 +35,9 @@
       },
       {
         "indexed": false,
-        "internalType": "uint256",
+        "internalType": "uint112",
         "name": "accountedInterest_",
-        "type": "uint256"
+        "type": "uint112"
       }
     ],
     "name": "IssuanceParamsUpdated",
@@ -72,6 +60,19 @@
       }
     ],
     "name": "MinRatioSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "principalOut_",
+        "type": "uint128"
+      }
+    ],
+    "name": "PrincipalOutUpdated",
     "type": "event"
   },
   {
@@ -108,7 +109,7 @@
   },
   {
     "inputs": [],
-    "name": "PRECISION",
+    "name": "HUNDRED_PERCENT",
     "outputs": [
       {
         "internalType": "uint256",
@@ -121,7 +122,7 @@
   },
   {
     "inputs": [],
-    "name": "SCALED_ONE",
+    "name": "PRECISION",
     "outputs": [
       {
         "internalType": "uint256",
@@ -165,9 +166,9 @@
     "name": "accountedInterest",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint112",
         "name": "",
-        "type": "uint256"
+        "type": "uint112"
       }
     ],
     "stateMutability": "view",
@@ -238,9 +239,9 @@
     "name": "domainEnd",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint48",
         "name": "",
-        "type": "uint256"
+        "type": "uint48"
       }
     ],
     "stateMutability": "view",
@@ -251,9 +252,9 @@
     "name": "domainStart",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint48",
         "name": "",
-        "type": "uint256"
+        "type": "uint48"
       }
     ],
     "stateMutability": "view",
@@ -441,133 +442,34 @@
     "name": "liquidationInfo",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "bool",
+        "name": "triggeredByGovernor",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint128",
         "name": "principal",
-        "type": "uint256"
+        "type": "uint128"
       },
       {
-        "internalType": "uint256",
+        "internalType": "uint120",
         "name": "interest",
-        "type": "uint256"
+        "type": "uint120"
       },
       {
         "internalType": "uint256",
-        "name": "platformFees",
+        "name": "lateInterest",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint96",
+        "name": "platformFees",
+        "type": "uint96"
       },
       {
         "internalType": "address",
         "name": "liquidator",
         "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "triggeredByGovernor",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "loanCounter",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "loanIdOf",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "loanWithEarliestPaymentDueDate",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "loans",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "previous",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "next",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "incomingNetInterest",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "refinanceInterest",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "issuanceRate",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "startDate",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "paymentDueDate",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "platformManagementFeeRate",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "delegateManagementFeeRate",
-        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -625,6 +527,100 @@
   },
   {
     "inputs": [],
+    "name": "paymentCounter",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "paymentIdOf",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paymentWithEarliestDueDate",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "payments",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "platformManagementFeeRate",
+        "type": "uint24"
+      },
+      {
+        "internalType": "uint24",
+        "name": "delegateManagementFeeRate",
+        "type": "uint24"
+      },
+      {
+        "internalType": "uint48",
+        "name": "startDate",
+        "type": "uint48"
+      },
+      {
+        "internalType": "uint48",
+        "name": "paymentDueDate",
+        "type": "uint48"
+      },
+      {
+        "internalType": "uint128",
+        "name": "incomingNetInterest",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "refinanceInterest",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint256",
+        "name": "issuanceRate",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "pool",
     "outputs": [
       {
@@ -667,22 +663,9 @@
     "name": "principalOut",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint128",
         "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "protocolPaused",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "protocolPaused_",
-        "type": "bool"
+        "type": "uint128"
       }
     ],
     "stateMutability": "view",
@@ -758,13 +741,58 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "sortedPayments",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "previous",
+        "type": "uint24"
+      },
+      {
+        "internalType": "uint24",
+        "name": "next",
+        "type": "uint24"
+      },
+      {
+        "internalType": "uint48",
+        "name": "paymentDueDate",
+        "type": "uint48"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "loan_",
         "type": "address"
       }
     ],
-    "name": "triggerCollateralLiquidation",
-    "outputs": [],
+    "name": "triggerDefault",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "liquidationComplete_",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "remainingLosses_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "platformFees_",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -774,11 +802,6 @@
         "internalType": "address",
         "name": "loan_",
         "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "newPaymentDueDate_",
-        "type": "uint256"
       },
       {
         "internalType": "bool",
@@ -796,9 +819,9 @@
     "name": "unrealizedLosses",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint128",
         "name": "",
-        "type": "uint256"
+        "type": "uint128"
       }
     ],
     "stateMutability": "view",

--- a/src/abis/LoanManagerInitializer.abi.json
+++ b/src/abis/LoanManagerInitializer.abi.json
@@ -21,9 +21,9 @@
     "name": "accountedInterest",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint112",
         "name": "",
-        "type": "uint256"
+        "type": "uint112"
       }
     ],
     "stateMutability": "view",
@@ -72,9 +72,9 @@
     "name": "domainEnd",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint48",
         "name": "",
-        "type": "uint256"
+        "type": "uint48"
       }
     ],
     "stateMutability": "view",
@@ -85,9 +85,9 @@
     "name": "domainStart",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint48",
         "name": "",
-        "type": "uint256"
+        "type": "uint48"
       }
     ],
     "stateMutability": "view",
@@ -149,133 +149,34 @@
     "name": "liquidationInfo",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "bool",
+        "name": "triggeredByGovernor",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint128",
         "name": "principal",
-        "type": "uint256"
+        "type": "uint128"
       },
       {
-        "internalType": "uint256",
+        "internalType": "uint120",
         "name": "interest",
-        "type": "uint256"
+        "type": "uint120"
       },
       {
         "internalType": "uint256",
-        "name": "platformFees",
+        "name": "lateInterest",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint96",
+        "name": "platformFees",
+        "type": "uint96"
       },
       {
         "internalType": "address",
         "name": "liquidator",
         "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "triggeredByGovernor",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "loanCounter",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "loanIdOf",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "loanWithEarliestPaymentDueDate",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "loans",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "previous",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "next",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "incomingNetInterest",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "refinanceInterest",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "issuanceRate",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "startDate",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "paymentDueDate",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "platformManagementFeeRate",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "delegateManagementFeeRate",
-        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -294,6 +195,100 @@
       {
         "internalType": "uint256",
         "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paymentCounter",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "paymentIdOf",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paymentWithEarliestDueDate",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "payments",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "platformManagementFeeRate",
+        "type": "uint24"
+      },
+      {
+        "internalType": "uint24",
+        "name": "delegateManagementFeeRate",
+        "type": "uint24"
+      },
+      {
+        "internalType": "uint48",
+        "name": "startDate",
+        "type": "uint48"
+      },
+      {
+        "internalType": "uint48",
+        "name": "paymentDueDate",
+        "type": "uint48"
+      },
+      {
+        "internalType": "uint128",
+        "name": "incomingNetInterest",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "refinanceInterest",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint256",
+        "name": "issuanceRate",
         "type": "uint256"
       }
     ],
@@ -331,9 +326,38 @@
     "name": "principalOut",
     "outputs": [
       {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "name": "sortedPayments",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "previous",
+        "type": "uint24"
+      },
+      {
+        "internalType": "uint24",
+        "name": "next",
+        "type": "uint24"
+      },
+      {
+        "internalType": "uint48",
+        "name": "paymentDueDate",
+        "type": "uint48"
       }
     ],
     "stateMutability": "view",
@@ -344,9 +368,9 @@
     "name": "unrealizedLosses",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "uint128",
         "name": "",
-        "type": "uint256"
+        "type": "uint128"
       }
     ],
     "stateMutability": "view",

--- a/src/abis/PoolManager.abi.json
+++ b/src/abis/PoolManager.abi.json
@@ -43,7 +43,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "loan",
+        "name": "loan_",
         "type": "address"
       }
     ],
@@ -733,12 +733,12 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "escorwShares_",
+        "name": "escrowShares_",
         "type": "uint256"
       },
       {
         "internalType": "address",
-        "name": "destination",
+        "name": "destination_",
         "type": "address"
       }
     ],
@@ -1125,35 +1125,6 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "assets_",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "owner_",
-        "type": "address"
-      }
-    ],
-    "name": "processWithdraw",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "redeemableShares_",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "resultingAssets_",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "address",
         "name": "loan_",
         "type": "address"
@@ -1343,7 +1314,7 @@
         "type": "address"
       }
     ],
-    "name": "triggerCollateralLiquidation",
+    "name": "triggerDefault",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1354,11 +1325,6 @@
         "internalType": "address",
         "name": "loan_",
         "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "newPaymentDueDate_",
-        "type": "uint256"
       }
     ],
     "name": "triggerDefaultWarning",

--- a/src/abis/PoolV2.abi.json
+++ b/src/abis/PoolV2.abi.json
@@ -143,6 +143,12 @@
         "internalType": "uint256",
         "name": "shares_",
         "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "escrowedShares_",
+        "type": "uint256"
       }
     ],
     "name": "RedemptionRequested",
@@ -242,6 +248,12 @@
         "indexed": false,
         "internalType": "uint256",
         "name": "assets_",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "escrowedShares_",
         "type": "uint256"
       }
     ],
@@ -932,7 +944,7 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "escrowShares_",
+        "name": "escrowedShares_",
         "type": "uint256"
       }
     ],
@@ -951,7 +963,7 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "escrowShares_",
+        "name": "escrowedShares_",
         "type": "uint256"
       }
     ],
@@ -977,7 +989,7 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "totalManagedAssets_",
+        "name": "totalAssets_",
         "type": "uint256"
       }
     ],
@@ -1056,7 +1068,7 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "totalManagedAssets_",
+        "name": "unrealizedLosses_",
         "type": "uint256"
       }
     ],


### PR DESCRIPTION
## Description

Updates `abi` folder (which subgraph imports) according to updated `bundle` per `maple-deploy` update of Pools v2 to `beta` release with this PR https://github.com/maple-labs/maple-deploy/pull/141
