### PR TITLE
Sc 9214 deploy sdk subgraph add loan 3 0 1 fix

### DIFF
--- a/config.json
+++ b/config.json
@@ -30,7 +30,7 @@
     },
     "loan": {
       "repo": "@maplelabs/loan",
-      "alias": ["loanV1", "loanV2", "loanV3", "loanV4"]
+      "alias": ["loanV1", "loanV2", "loanV3", "loanV301", "loanV4"]
     },
     "mapleGlobals": {
       "repo": "@maplelabs/globals",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@maplelabs/loanV1": "npm:@maplelabs/loan@v1.0.0",
     "@maplelabs/loanV2": "npm:@maplelabs/loan@v2.0.0",
     "@maplelabs/loanV3": "npm:@maplelabs/loan@3.0.0",
-    "@maplelabs/loanV3.0.1": "npm:@maplelabs/loan@3.0.1-rc.0",
+    "@maplelabs/loanV301": "npm:@maplelabs/loan@3.0.1-rc.0",
     "@maplelabs/loanV4": "npm:@maplelabs/loan@4.0.0-rc.0",
     "@maplelabs/mapleGlobals": "npm:@maplelabs/globals@v1.0.0",
     "@maplelabs/mapleGlobalsV2": "npm:@maplelabs/globals-v2@1.0.0-rc.0",

--- a/scripts/build-typechain.js
+++ b/scripts/build-typechain.js
@@ -64,7 +64,7 @@ async function buildTypechain() {
   const config = getParsedConfig()
   // These manual changes augment the npm packages. src/abis/ contains the updates already.
   mergeEvents({ src: 'loanV4/abis/Refinancer.json', dst: 'loanV4/abis/MapleLoan.json' })
-  mergeEvents({ src: 'loanV3.0.1/abis/Refinancer.json', dst: 'loanV3.0.1/abis/MapleLoan.json' })
+  mergeEvents({ src: 'loanV301/abis/Refinancer.json', dst: 'loanV301/abis/MapleLoan.json' })
   mergeEvents({ src: 'loanV3/abis/Refinancer.json', dst: 'loanV3/abis/MapleLoan.json' })
   mergeEvents({ src: 'poolV2/abis/PoolManagerInitializer.json', dst: 'poolV2/abis/PoolManager.json' })
   overwriteEventParams({

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,7 +956,7 @@
   resolved "https://registry.yarnpkg.com/@maplelabs/loan/-/loan-2.0.0.tgz#c7ae112482cb45c5815bcae1f85afd9d3d39b8d9"
   integrity sha512-cDE4dzEB2pjL4zJXPX8PRXtYwYLj2CX9hePPI8xygS61hNN0KTw0cuaM2PVc+dFBja9Ejpc2+uaap3SEvpi0vw==
 
-"@maplelabs/loanV3.0.1@npm:@maplelabs/loan@3.0.1-rc.0":
+"@maplelabs/loanV301@npm:@maplelabs/loan@3.0.1-rc.0":
   version "3.0.1-rc.0"
   resolved "https://registry.yarnpkg.com/@maplelabs/loan/-/loan-3.0.1-rc.0.tgz#91332db3a38003332380a4a34819b357449659d7"
   integrity sha512-R2cy9lW1DC174nnH3NBr3LB9UJwscJO9xl89weO6s5vIZ3fin/j50Lu4hm91MTXFRt30MfUWiHYV22abMrhbYA==


### PR DESCRIPTION
|       Type        |              Ticket              |
| :---------------: | :------------------------------: |
| Bug| [Link](https://app.shortcut.com/maplefinance/story/9214/deploy-sdk-subgraph-add-loan-3-0-1) |

## Problem

loanV301 was broken when generating the typechain files.

## Solution

Rename from alias loanV3.0.1 to loanV301

