### PR TITLE
feat: update ChainLinkEmulator abi with aggregator

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@maplelabs/debtLockerV2": "npm:@maplelabs/debt-locker@v2.0.0",
     "@maplelabs/debtLockerV3": "npm:@maplelabs/debt-locker@v3.0.0",
     "@maplelabs/debtLockerV4": "npm:@maplelabs/debt-locker@4.0.0-rc.0",
-    "@maplelabs/environmentMocks": "npm:@maplelabs/environment-mocks@v0.0.1",
+    "@maplelabs/environmentMocks": "npm:@maplelabs/environment-mocks@v2.0.0-beta.0",
     "@maplelabs/fundingLocker": "npm:@maplelabs/funding-locker@v1.0.0",
     "@maplelabs/lateFeeCalculator": "npm:@maplelabs/late-fee-calculator@v1.0.0",
     "@maplelabs/liquidationsV2": "npm:@maplelabs/liquidations@2.0.0-rc.0",

--- a/src/abis/ChainLinkAggregatorEmulator.abi.json
+++ b/src/abis/ChainLinkAggregatorEmulator.abi.json
@@ -7,11 +7,6 @@
         "type": "address"
       },
       {
-        "internalType": "address",
-        "name": "_aggregator",
-        "type": "address"
-      },
-      {
         "internalType": "string",
         "name": "_description",
         "type": "string"
@@ -21,17 +16,29 @@
     "type": "constructor"
   },
   {
-    "inputs": [],
-    "name": "aggregator",
-    "outputs": [
+    "anonymous": false,
+    "inputs": [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        "indexed": true,
+        "internalType": "int256",
+        "name": "current",
+        "type": "int256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "roundId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "updatedAt",
+        "type": "uint256"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "name": "AnswerUpdated",
+    "type": "event"
   },
   {
     "inputs": [],
@@ -61,7 +68,7 @@
   },
   {
     "inputs": [],
-    "name": "getLatestPrice",
+    "name": "price",
     "outputs": [
       {
         "internalType": "int256",
@@ -70,6 +77,19 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "_price",
+        "type": "int256"
+      }
+    ],
+    "name": "setPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {

--- a/src/abis/ChainLinkEmulator.abi.json
+++ b/src/abis/ChainLinkEmulator.abi.json
@@ -42,6 +42,19 @@
   },
   {
     "inputs": [],
+    "name": "aggregator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "decimals",
     "outputs": [
       {

--- a/src/abis/ChainLinkEmulatorFactory.abi.json
+++ b/src/abis/ChainLinkEmulatorFactory.abi.json
@@ -50,7 +50,7 @@
         "type": "string"
       }
     ],
-    "name": "newAgg",
+    "name": "newOracle",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,10 +921,10 @@
   resolved "https://registry.yarnpkg.com/@maplelabs/debt-locker/-/debt-locker-4.0.0-rc.0.tgz#adee2c6c3d3ed8a9234963d8c7fb3181fc49f47b"
   integrity sha512-RT84p+ABhovXF1/GOQfelmSNqfsGzEYwVyPuQuhe58rNlBKHc9BNrKF2qgvrIamdjOMD4mkbCyRWAj3M/Zdlnw==
 
-"@maplelabs/environmentMocks@npm:@maplelabs/environment-mocks@v0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@maplelabs/environment-mocks/-/environment-mocks-0.0.1.tgz#c1e788a8945491d9c5dcd88cea649fa43d5d0218"
-  integrity sha512-tK3LNpu5L16KsOLOohIHX0J2z+01SQcbl48sxs9IkROXoM2Dipdp+pJT1an7KTCdye8kWoeAmzwS+9BeJLZZyQ==
+"@maplelabs/environmentMocks@npm:@maplelabs/environment-mocks@v2.0.0-beta.0":
+  version "2.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@maplelabs/environment-mocks/-/environment-mocks-2.0.0-beta.0.tgz#2b64b869b7f5f79228af58b919e274bfe257d5ef"
+  integrity sha512-IJ+mw9l9zDm2OyFnQvZNCH/MvZxyqv4JtsGhXXDsMUgFXoJJu/pXEpXIygMDug2B8I9gaOOykXZCR77Uai7Q7A==
 
 "@maplelabs/fundingLocker@npm:@maplelabs/funding-locker@v1.0.0":
   version "1.0.0"


### PR DESCRIPTION
|       Type        |              Ticket              |
| :---------------: | :------------------------------: |
| Feature | [Link](https://app.shortcut.com/maplefinance/story/9521/subgraph-spike-on-removing-dependency-on-balance-pools) |

## Problem

Need to be able to index the chainlink price feed updates.

## Solution

Update the emulator abi in order to access the aggregator address so we can access it.

##  Related PRs:

- https://github.com/maple-labs/environment-mocks/pull/1
- https://github.com/maple-labs/maple-deploy/pull/197
- https://github.com/maple-labs/maple-subgraph/pull/335


