### PR TITLE
feat: update mergeEvents process to remove manual copying

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "tsc --noEmit && eslint '*/**/*.{js,ts}' --quiet",
     "lint:fix": "tsc --noEmit && eslint '*/**/*.{js,ts}' --quiet --fix",
     "format": "prettier --write '*/**/*.ts'",
+    "preinstall": "rm -rf node_modules",
     "postinstall": "yarn build-typechain",
     "rebuild": "yarn unlink && yarn build && yarn link"
   },


### PR DESCRIPTION
|       Type        |              Ticket              |
| :---------------: | :------------------------------: |
| Bug/Feature/Chore | [Link](https://app.shortcut.com/maplefinance/story/9164/spike-investigate-abi-processing-automation) |

## Problem

Awkward manual process for updating abis.

This stops need for copying the `build-typechain` patched abis from `node_modules into` `src/abis`.

## Still To Do

Ensure there is no need to copy `abis` from `maple-deploy` by generating them from `node_modules` directly like in the `bundle` script in `maple-deploy`.

Think of adding a script like`build-addresses` for abis:
```json
    "build-addresses": "node ./scripts/build-addresses.js",
    "build-abis": "node ./scripts/build-abis.js",
```
