### PR TITLE
sc-15947-feature-sdk-add-signed-transaction-broadcast-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A JavaScript SDK for interacting with Maple Protocol's smart contracts.
 - [Additional Resources](#additional-resources)
 - [Utils](#utils)
   - [Generating Unsigned Transaction Data](#generating-unsigned-transaction-data)
+  - [Generating Signed Transaction Data](#generating-signed-transaction-data)
+  - [Broadcasting Signed Transactions](#broadcasting-signed-transactions)
 
 ## Getting Started
 
@@ -90,23 +92,23 @@ const method = await (await poolContract.deposit(depositAmount)).wait()
 
 **Generating Unsigned Transaction Data**
 
-This feature allows you to generate unsigned transaction data, facilitating the creation of transactions that can later be signed and sent to the network. This is particularly useful for offline transaction preparation or when keys are managed externally.
+This utility allows you to generate unsigned transaction data, facilitating the creation of transactions that can later be signed and sent to the network. This is particularly useful for offline transaction preparation or when keys are managed externally.
 Usage
 
 ```
 import { utils } from '@maplelabs/maple-js'
 
-const { txBytes, txInstance } = utils.generateTransactionData(parameters)
+const { txBytes, txInstance } = utils.generateUnsignedTransactionData(parameters)
 ```
 
-The `generateTransactionData` function supports creating unsigned transactions for specific actions, currently including `poolDeposit` and `poolQueueWithdrawal`. Depending on the action, parameters must be provided accordingly:
+The `generateUnsignedTransactionData` function supports creating unsigned transactions for specific actions, currently including `poolDeposit` and `poolQueueWithdrawal`. Depending on the action, parameters must be provided accordingly:
 
 - For `poolDeposit`, specify the deposit amount in assets.
 - For `poolQueueWithdrawal`, specify the withdrawal amount in shares.
 
 **_Parameters_**
 
-All calls to `generateTransactionData` require the following parameters:
+All calls to `generateUnsignedTransactionData` require the following parameters:
 
 ```
 interface CommonInputs {
@@ -134,9 +136,50 @@ interface CommonInputs {
   }
 ```
 
+**Generating Signed Transaction Data**
+This utility provides the functionality to combine unsigned transaction with a signature to create a signed transaction string. This is crucial for scenarios where transactions are prepared offline or in secure environments.
+Usage
+
+```
+import { utils } from '@maplelabs/maple-js'
+
+const signedTxData = utils.generateSignedTransactionData({
+  txBytes: 'unsignedTransactionBytes',
+  signature: 'signature'
+})
+```
+
+**_Parameters_**
+
+- `txBytes`: The serialized unsigned transaction data.
+- ``signature`: The signature obtained from signing the transaction hash.
+
+This function returns the serialized signed transaction data, ready for broadcasting to the Ethereum network.
+
+**Broadcasting Signed Transactions**
+This utilit allows you to broadcast a signed transaction to the Ethereum network. This step is the final stage in submitting transactions, where the transaction is sent to a node in the network for processing and inclusion in the blockchain.
+
+Usage
+
+```
+import { utils } from '@maplelabs/maple-js'
+
+const txReceipt = await utils.broadcastSignedTransaction(
+  'signedTransactionData',
+  'rpcUrl'
+)
+```
+
+**_Parameters_**
+
+- `signedTxData`: The serialized signed transaction data.
+- `rpcUrl`: The URL of the Ethereum JSON-RPC endpoint to which you are broadcasting the transaction.
+
+This function sends the signed transaction to the network and returns the transaction receipt once the transaction has been processed.
+
 **_Example_**
 
-An example usage of this feature, including parameter setup and function calls, can be found in the repository at `src/helpers/serialiseExampleUse`.
+An example usage of these utilities, including parameter setup and function calls, can be found in the repository at `src/helpers/serialiseExampleUse`.
 
 ## Additional Resources
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maplelabs/maple-js",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Maple SDK for JavaScript",
   "author": "Maple Labs",
   "license": "AGPL-3.0-only",

--- a/src/helpers/serialiseExampleUse.ts
+++ b/src/helpers/serialiseExampleUse.ts
@@ -38,7 +38,6 @@ async function main() {
       depositAmount: amount
     }
   })
-  // console.log({ txBytes })
 
   // const { txBytes, txInstance }: UnsignedTransactionBundle = await generateTransactionData({
   //   provider,
@@ -49,8 +48,6 @@ async function main() {
   //     withdrawalAmount: amount
   //   }
   // })
-
-  // console.log({ txBytes })
 
   // 🚨 3) Sign the transaction 🚨
   const deserializeTx = parseTransaction(txBytes)

--- a/src/helpers/serialiseExampleUse.ts
+++ b/src/helpers/serialiseExampleUse.ts
@@ -38,7 +38,7 @@ async function main() {
       depositAmount: amount
     }
   })
-  console.log({ txBytes })
+  // console.log({ txBytes })
 
   // const { txBytes, txInstance }: UnsignedTransactionBundle = await generateTransactionData({
   //   provider,
@@ -72,8 +72,6 @@ async function main() {
     type
   }
 
-  console.log('🐶 :::', { transactionRequest })
-
   const signedTx = await walletWithProvider.signTransaction(transactionRequest)
   const transactionParsed = parseTransaction(signedTx)
   const { r, s, v } = transactionParsed
@@ -83,8 +81,6 @@ async function main() {
   const joinedSignature = joinSignature({ r, s, v })
 
   const signedTxData = await generateSignedTransactionData({ txBytes, signature: joinedSignature })
-
-  console.log({ signedTxData })
 
   // 🚨 4) Broadcast the transaction 🚨
   const rpcUrl = process.env.RPC_URL as string

--- a/src/helpers/serialiseTransaction.ts
+++ b/src/helpers/serialiseTransaction.ts
@@ -50,8 +50,6 @@ const createUnsignedTransactionBundle = async (
     // const maxPriorityFeePerGas = feeData.maxPriorityFeePerGas || ZERO
     // const maxFeePerGas = feeData.maxFeePerGas || ZERO
 
-    // console.log('🐸', { feeData, maxPriorityFeePerGas, maxFeePerGas })
-
     // Get current nonce
     const nonce = await provider.getTransactionCount(wallet)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,11 @@ import sepoliaDevAddresses from './addresses/sepolia-dev'
 import sepoliaProdAddresses from './addresses/sepolia-prod'
 
 // utils
-import { generateTransactionData } from 'helpers/serialiseTransaction'
+import {
+  generateUnsignedTransactionData,
+  generateSignedTransactionData,
+  broadcastSignedTransaction
+} from 'helpers/serialiseTransaction'
 
 const debtLockerV2 = {
   core: debtLockerV2Imports.DebtLockerV2Abi__factory,
@@ -359,7 +363,9 @@ interface ContractTypes {
 
 // Utils
 const utils = {
-  generateTransactionData
+  generateUnsignedTransactionData,
+  generateSignedTransactionData,
+  broadcastSignedTransaction
 }
 
 export {


### PR DESCRIPTION
|       Type        |              Ticket              |
| :---------------: | :------------------------------: |
| Feature | [Link](https://app.shortcut.com/maplefinance/story/15947/sdk-add-signed-transaction-broadcast-utils-to-sdk) |

## Problem
- Adds `generateSignedTransactionData(txBytes: string, signature: string)`
- Adds `broadcastTransaction(transactionData: string, rpcUrl: string)`
- Renames `generateTransactionData` to `generateUnsignedTransactionData`