### PR TITLE
Sc 21436 chore  deploy deploy new wm v2 contract

### DIFF
--- a/config.json
+++ b/config.json
@@ -122,6 +122,9 @@
     "withdrawalManagerQueue": {
       "contracts": ["WithdrawalManagerQueue", "WithdrawalManagerQueueInitializer", "WithdrawalManagerQueueFactory"]
     },
+    "withdrawalManagerQueueV2": {
+      "contracts": ["WithdrawalManagerQueueV2"]
+    },
     "xmpl": {
       "contracts": ["xMPL"]
     }

--- a/scripts/build-typechain.js
+++ b/scripts/build-typechain.js
@@ -145,6 +145,10 @@ async function buildTypechain() {
     src: 'WithdrawalManagerQueueInitializer.abi.json',
     dst: 'WithdrawalManagerQueue.abi.json'
   })
+  mergeEvents({
+    src: 'WithdrawalManagerQueueInitializer.abi.json',
+    dst: 'WithdrawalManagerQueueV2.abi.json'
+  })
 
   overwriteEventParams({
     file: 'PoolV1',

--- a/src/abis/WithdrawalManagerQueueV2.abi.json
+++ b/src/abis/WithdrawalManagerQueueV2.abi.json
@@ -33,7 +33,13 @@
         "internalType": "address"
       }
     ],
-    "outputs": [],
+    "outputs": [
+      {
+        "name": "lastRequestId_",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
     "stateMutability": "nonpayable"
   },
   {
@@ -373,6 +379,11 @@
         "name": "owner_",
         "type": "address",
         "internalType": "address"
+      },
+      {
+        "name": "requestIds_",
+        "type": "uint128[]",
+        "internalType": "uint128[]"
       }
     ],
     "outputs": [],
@@ -407,14 +418,14 @@
     "name": "requestIds",
     "inputs": [
       {
-        "name": "",
+        "name": "owner_",
         "type": "address",
         "internalType": "address"
       }
     ],
     "outputs": [
       {
-        "name": "",
+        "name": "requestId_",
         "type": "uint128",
         "internalType": "uint128"
       }
@@ -441,6 +452,30 @@
         "name": "shares_",
         "type": "uint256",
         "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "requestsByOwner",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "requestIds_",
+        "type": "uint128[]",
+        "internalType": "uint128[]"
+      },
+      {
+        "name": "shares_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
       }
     ],
     "stateMutability": "view"
@@ -504,6 +539,54 @@
   },
   {
     "type": "function",
+    "name": "updateShares",
+    "inputs": [
+      {
+        "name": "requestId_",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "newSharesTotal_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "updatedRequestId_",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateSharesBatch",
+    "inputs": [
+      {
+        "name": "requestIds_",
+        "type": "uint128[]",
+        "internalType": "uint128[]"
+      },
+      {
+        "name": "newSharesTotals_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "updatedRequestIds_",
+        "type": "uint128[]",
+        "internalType": "uint128[]"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "upgrade",
     "inputs": [
       {
@@ -519,6 +602,25 @@
     ],
     "outputs": [],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "userEscrowedShares",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "event",

--- a/src/abis/WithdrawalManagerQueueV2.abi.json
+++ b/src/abis/WithdrawalManagerQueueV2.abi.json
@@ -1,0 +1,687 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "poolManager",
+        "type": "address"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "type": "function",
+    "name": "addShares",
+    "inputs": [
+      {
+        "name": "shares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "asset",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "asset_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "factory",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "factory_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "globals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "globals_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "governor",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "governor_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isInExitWindow",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isInExitWindow_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "isManualWithdrawal",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "lockedLiquidity",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "lockedLiquidity_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "lockedShares",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lockedShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "manualSharesAvailable",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "arguments_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pool",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "poolDelegate",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "poolDelegate_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "poolManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewRedeem",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "shares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "redeemableShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "resultingAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewWithdraw",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "assets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "redeemableAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "resultingShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "processExit",
+    "inputs": [
+      {
+        "name": "shares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "redeemableShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "resultingAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "processRedemptions",
+    "inputs": [
+      {
+        "name": "maxSharesToProcess_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "queue",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "nextRequestId",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "lastRequestId",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "removeRequest",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "removeShares",
+    "inputs": [
+      {
+        "name": "shares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "sharesReturned_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestIds",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "requests",
+    "inputs": [
+      {
+        "name": "requestId_",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "shares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "securityAdmin",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "securityAdmin_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setImplementation",
+    "inputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setManualWithdrawal",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "isManual_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "totalShares",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "upgrade",
+    "inputs": [
+      {
+        "name": "version_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "arguments_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "ManualSharesDecreased",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sharesDecreased",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ManualSharesIncreased",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sharesAdded",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ManualWithdrawalSet",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "isManual",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RequestCreated",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint128",
+        "indexed": true,
+        "internalType": "uint128"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RequestDecreased",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint128",
+        "indexed": true,
+        "internalType": "uint128"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RequestProcessed",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint128",
+        "indexed": true,
+        "internalType": "uint128"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RequestRemoved",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint128",
+        "indexed": true,
+        "internalType": "uint128"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "toVersion_",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "arguments_",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  }
+]

--- a/src/addresses/base-mainnet-prod.ts
+++ b/src/addresses/base-mainnet-prod.ts
@@ -154,6 +154,7 @@ export default {
   WithdrawalManagerFactory: '0x0434FC9e7D88294dAac40dDF316754B2053D613b',
   WithdrawalManagerInitializer: '0x899b7d637e35B2C57E845dB1064a4e58639D3A8D',
   WithdrawalManagerQueue: '0x899B57Bbd8597aa2d1898476504f479c982c5c2c',
+  WithdrawalManagerQueueV2: '0x0000000000000000000000000000000000000000',
   WithdrawalManagerQueueFactory: '0xca33105902E8d232DDFb9f71Ff3D79C7E7f2C4e5',
   WithdrawalManagerQueueInitializer: '0x637f8dC4C4d07D1CC30ae131fA94A060dee6be96',
   xMPL: '0x0000000000000000000000000000000000000000',

--- a/src/addresses/mainnet-dev.ts
+++ b/src/addresses/mainnet-dev.ts
@@ -154,6 +154,7 @@ export default {
   WithdrawalManagerFactory: '0xb9e25B584dc4a7C9d47aEF577f111fBE5705773B',
   WithdrawalManagerInitializer: '0x1063dCa836894b12f29003CA2899ff806A2B0B31',
   WithdrawalManagerQueue: '0x899B57Bbd8597aa2d1898476504f479c982c5c2c',
+  WithdrawalManagerQueueV2: '0x0000000000000000000000000000000000000000',
   WithdrawalManagerQueueFactory: '0xca33105902E8d232DDFb9f71Ff3D79C7E7f2C4e5',
   WithdrawalManagerQueueInitializer: '0x637f8dC4C4d07D1CC30ae131fA94A060dee6be96',
   xMPL: '0x4937a209d4cdbd3ecd48857277cfd4da4d82914c',

--- a/src/addresses/mainnet-prod.ts
+++ b/src/addresses/mainnet-prod.ts
@@ -154,6 +154,7 @@ export default {
   WithdrawalManagerFactory: '0xb9e25B584dc4a7C9d47aEF577f111fBE5705773B',
   WithdrawalManagerInitializer: '0x1063dCa836894b12f29003CA2899ff806A2B0B31',
   WithdrawalManagerQueue: '0x899B57Bbd8597aa2d1898476504f479c982c5c2c',
+  WithdrawalManagerQueueV2: '0x0000000000000000000000000000000000000000',
   WithdrawalManagerQueueFactory: '0xca33105902E8d232DDFb9f71Ff3D79C7E7f2C4e5',
   WithdrawalManagerQueueInitializer: '0x637f8dC4C4d07D1CC30ae131fA94A060dee6be96',
   xMPL: '0x4937a209d4cdbd3ecd48857277cfd4da4d82914c',

--- a/src/addresses/sepolia-dev.ts
+++ b/src/addresses/sepolia-dev.ts
@@ -154,6 +154,7 @@ export default {
   WithdrawalManagerFactory: '0xbdd040d545f86acd1a0edb4419ef9ee9a24cf65d',
   WithdrawalManagerInitializer: '0x30916aace8b47c32dbff23dc66693e67fa97d452',
   WithdrawalManagerQueue: '0x06823746c0919f46cec0fe35979e9a38184a5849',
+  WithdrawalManagerQueueV2: '0x9276c34b359a97d17012977681769ef09147567b',
   WithdrawalManagerQueueFactory: '0xf6230e021fcb3bf767a668f8c5c66926cc8249df',
   WithdrawalManagerQueueInitializer: '0x54b6bcfa750dabf8a48bf63733ce175e12319daa',
   xMPL: '0x23b2c26f1021ec01e41f4b08c790821167056110',

--- a/src/addresses/sepolia-prod.ts
+++ b/src/addresses/sepolia-prod.ts
@@ -154,6 +154,7 @@ export default {
   WithdrawalManagerFactory: '0x239a2f25944728d73bb6553ac5755cb8f3203e76',
   WithdrawalManagerInitializer: '0x99854be1e2133c9b098fb9185065f0f2c8e5fc36',
   WithdrawalManagerQueue: '0x633222d7a279a549800d91041b3cec29e0ae378f',
+  WithdrawalManagerQueueV2: '0x0000000000000000000000000000000000000000',
   WithdrawalManagerQueueFactory: '0x3e2a11fd07acafa6b2c48da113925cd0a736158c',
   WithdrawalManagerQueueInitializer: '0xb57cbc43f1b1aad439c5292d4f895d1dc7402e0d',
   xMPL: '0x789b261518fd01e8a3e31716639174343ae92f19',

--- a/src/addresses/sepolia-prod.ts
+++ b/src/addresses/sepolia-prod.ts
@@ -154,7 +154,7 @@ export default {
   WithdrawalManagerFactory: '0x239a2f25944728d73bb6553ac5755cb8f3203e76',
   WithdrawalManagerInitializer: '0x99854be1e2133c9b098fb9185065f0f2c8e5fc36',
   WithdrawalManagerQueue: '0x633222d7a279a549800d91041b3cec29e0ae378f',
-  WithdrawalManagerQueueV2: '0x0000000000000000000000000000000000000000',
+  WithdrawalManagerQueueV2: '0x54d732b916c651f774444e0de32b9f89329d6448',
   WithdrawalManagerQueueFactory: '0x3e2a11fd07acafa6b2c48da113925cd0a736158c',
   WithdrawalManagerQueueInitializer: '0xb57cbc43f1b1aad439c5292d4f895d1dc7402e0d',
   xMPL: '0x789b261518fd01e8a3e31716639174343ae92f19',

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import * as syrupTokenImports from './typechain/syrupToken'
 import * as withdrawalManagerImports from './typechain/withdrawalManager'
 import * as withdrawalManagerCyclicalImports from './typechain/withdrawalManagerCyclical'
 import * as withdrawalManagerQueueImports from './typechain/withdrawalManagerQueue'
+import * as withdrawalManagerQueueV2Imports from './typechain/withdrawalManagerQueueV2'
 import * as xmplImports from './typechain/xmpl'
 
 // Addresses
@@ -250,6 +251,10 @@ const withdrawalManagerQueue = {
   core: withdrawalManagerQueueImports.WithdrawalManagerQueueAbi__factory,
   initializer: withdrawalManagerQueueImports.WithdrawalManagerQueueInitializerAbi__factory,
   factory: withdrawalManagerQueueImports.WithdrawalManagerQueueFactoryAbi__factory
+}
+
+const withdrawalManagerQueueV2 = {
+  core: withdrawalManagerQueueV2Imports.WithdrawalManagerQueueV2Abi__factory
 }
 
 const xmpl = {


### PR DESCRIPTION
|       Type        |              Ticket              |
| :---------------: | :------------------------------: |
| Feature | [Link](https://app.shortcut.com/maplefinance/story/21436/deploy-deploy-new-wm-v2-contract) |

## Description

- Introduce `withdrawalManagerQueueV2` package with `WithdrawalManagerQueueV2` implementation contract
- Add the contract's address in `sepolia-dev` & `sepolia-prod`
- ABI diff v2 > v2 can be found [here](https://github.com/maple-labs/maple-js/pull/230/commits/c85bcb4410affe438d70fb0a5701049297bf5cf8)

Verified contract [sepolia-dev]: https://sepolia.etherscan.io/address/0x9276c34b359a97d17012977681769ef09147567b#code

Verified contract [sepolia-prod]: 
https://sepolia.etherscan.io/address/0x54d732B916c651F774444e0de32b9f89329d6448#code