### PR TITLE
chore: Configure `npmMinimalAgeGate` quarantine window

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ enableImmutableInstalls: true
 enableScripts: false
 
 nodeLinker: node-modules
+
+npmMinimalAge: 7d

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,4 +6,4 @@ enableScripts: false
 
 nodeLinker: node-modules
 
-npmMinimalAge: 7d
+npmMinimalAgeGate: 7d


### PR DESCRIPTION
|  Type  |  Ticket  |
| :---:  | :------: |
| Chore  | OFFP-262 |

## Problem

No protection against freshly-published malicious packages. Same-day supply chain attacks (e.g., axios@1.14.1 pulling in malicious `plain-crypto-js`) can enter the dependency tree immediately.

## Solution

Add `npmMinimalAgeGate: 7d` to `.yarnrc.yml`. Yarn will refuse to resolve any package version published less than 7 days ago. No lockfile or runtime changes — only affects future dependency resolution.