### PR TITLE
chore: Add standard npm Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    groups:
+      security-patches:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      prod-dependencies:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Add Dependabot config (previously had none) with GH Actions + npm ecosystems
- npm config matches hub's standard template (OFFP-283)
- Groups: security patches batched, prod minor/patch, dev minor/patch
- Majors ignored (handled manually)
- Includes cooldown (7 days) and rebase disabled

Part of [OFFP-283](https://linear.app/maplefinance/issue/OFFP-283)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated dependency management configuration to systematically scan and manage updates for GitHub Actions and npm dependencies with controlled release schedules and security patch prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->