### PR TITLE
chore: Harden the npm release pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      ## Uncomment once separate ticket on hardening is done
+      # - name: Harden runner
+      #   uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      #   with:
+      #     egress-policy: audit
+
+      - name: Set up Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall
+
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.14.1
+
+      - name: Enable corepack and install dependencies
+        run: |
+          corepack enable
+          sfw yarn install --immutable
+
+      - name: Build
+        run: |
+          yarn build-typechain
+          yarn build
+
+      - name: Lint and typecheck
+        run: yarn lint
+
+      # `yarn test` is not run here: the jest suites are integration tests
+      # that call live contracts over an RPC endpoint and fail without one.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,11 +13,20 @@ on:
           - minor
           - major
 
+# Least-privilege defaults; the release job below grants only what it needs.
+permissions: {}
+
 jobs:
   release-api:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # Gate the deployment behind a GitHub Environment so it can carry
+    # protection rules (required reviewers, branch restrictions, secrets).
+    environment: npm
+
+    permissions:
+      contents: write   # push the version bump commit/tag and create the release
+      id-token: write   # mint the OIDC token for npm trusted publishing + provenance
 
     steps:
       - name: Checkout Repo
@@ -29,6 +38,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.14.1
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Enable corepack and install dependencies
         run: |
@@ -47,22 +57,19 @@ jobs:
           npm version ${{ github.event.inputs.version_type }} -m "Bump version to %s"
           echo "NEW_VERSION=v$(node -p "require('./package.json').version")" >> $GITHUB_ENV
 
-      - name: Authenticate with NPM
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_ACCESS_TOKEN }}" > ~/.npmrc
-
       - name: Publish to NPM
+        # No NPM_ACCESS_TOKEN: authentication is via OIDC trusted publishing,
+        # which also signs and attaches a provenance attestation.
         run: |
           npm config set scope maplelabs
-          npm publish --access=public
+          npm publish --provenance --access=public
 
       - name: Push changes
-        env:
-          PAT: ${{ secrets.PAT }}
         run: |
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           echo "Pushing changes to branch: $CURRENT_BRANCH"
-          git push --force https://x-access-token:$PAT@github.com/${{ github.repository }} HEAD:$CURRENT_BRANCH --follow-tags
+          # Uses the GITHUB_TOKEN credentials persisted by actions/checkout.
+          git push --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}" HEAD:$CURRENT_BRANCH --follow-tags
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,9 +76,9 @@ jobs:
           PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           if [ "$PRERELEASE" = "true" ]; then
-            npm publish --ignore-scripts --dry-run
+            npm publish --ignore-scripts --provenance --access public --dry-run
           else
-            npm publish --ignore-scripts
+            npm publish --ignore-scripts --provenance --access public
           fi
 
       - name: Verify published package and provenance

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,104 +1,109 @@
-name: Release Version
+name: Publish Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version_type:
-        description: 'Version update type'
-        required: true
-        default: 'patch'
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
+  release:
+    types: [published]
 
-# Least-privilege default; the release job below grants only what it needs.
 permissions: {}
 
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
 jobs:
-  release-api:
+  publish:
     runs-on: ubuntu-latest
 
-    # Gate publishing behind a protected GitHub Environment. Configure a
-    # required reviewer (and branch restriction) on the `npm` environment in
-    # repo settings so every publish needs a manual approval.
     environment: npm
 
     permissions:
-      contents: write   # create the GitHub release
+      contents: read    # actions/checkout
       id-token: write   # mint the OIDC token for npm trusted publishing + provenance
 
     steps:
-      # Socket Firewall blocks installation of known-malicious packages by
-      # proxying the install. Added to the runner before any install runs.
-      - name: Set up Socket Firewall
-        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1
-        with:
-          mode: firewall-free
+      ## Uncomment once separate ticket on hardening is done. When flipping to
+      ## egress-policy: block, the allowlist MUST include the Sigstore endpoints
+      ## (fulcio.sigstore.dev, rekor.sigstore.dev, tuf-repo-cdn.sigstore.dev)
+      ## and *.actions.githubusercontent.com (the Actions OIDC token service),
+      ## or provenance signing fails.
+      # - name: Harden runner
+      #   uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      #   with:
+      #     egress-policy: audit
 
-      # Short-lived, scoped GitHub App token replaces the long-lived PAT.
-      # The App must have contents:write on this repo and be added to any
-      # branch-protection bypass list so it can push the version-bump commit.
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      - name: Set up Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          mode: firewall
 
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0 # Ensures tags are also fetched
-          # Persist the App token so the push step below is authenticated by it.
-          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0 # full history: the guard below checks tag ancestry
+          persist-credentials: false # no git writes in this workflow
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.14.1
-          registry-url: 'https://registry.npmjs.org'
+
+      - name: Guard - tag matches package.json and is on main
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "::error::Release tag $TAG does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::Release tag $TAG does not point to a commit on main"
+            exit 1
+          fi
 
       - name: Enable corepack and install dependencies
-        # Install is routed through Socket Firewall (`sfw`).
         run: |
           corepack enable
-          sfw yarn install
+          sfw yarn install --immutable
 
       - name: Build
         run: |
           yarn build-typechain
           yarn build
 
-      - name: Bump version
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          npm version ${{ github.event.inputs.version_type }} -m "Bump version to %s"
-          echo "NEW_VERSION=v$(node -p "require('./package.json').version")" >> $GITHUB_ENV
-
       - name: Publish to NPM
-        # No NPM_ACCESS_TOKEN and no ~/.npmrc write: authentication is via OIDC
-        # trusted publishing, which also signs and attaches a provenance
-        # attestation. Configure the trusted publisher for @maplelabs/maple-js
-        # on npmjs.com (this repo + workflow + `npm` environment).
-        run: |
-          npm config set scope maplelabs
-          npm publish --provenance --access=public
-
-      - name: Push changes
-        run: |
-          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-          echo "Pushing changes to branch: $CURRENT_BRANCH"
-          # Fast-forward push via the persisted App-token credentials; no --force.
-          git push --follow-tags origin HEAD:"$CURRENT_BRANCH"
-
-      - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
-          gh release create "$NEW_VERSION" \
-          --repo="$GITHUB_REPOSITORY" \
-          --title="$NEW_VERSION" \
-          --generate-notes
+          if [ "$PRERELEASE" = "true" ]; then
+            npm publish --ignore-scripts --dry-run
+          else
+            npm publish --ignore-scripts
+          fi
+
+      - name: Verify published package and provenance
+        if: ${{ !github.event.release.prerelease }}
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG#v}"
+          # npm audit signatures verifies the *installed* tree, so install the
+          # freshly published version in a clean directory and verify there.
+          VERIFY_DIR="$RUNNER_TEMP/verify-publish"
+          mkdir -p "$VERIFY_DIR" && cd "$VERIFY_DIR"
+          npm init -y > /dev/null
+          # The registry can lag a few seconds behind a publish.
+          for i in 1 2 3 4 5; do
+            npm install --ignore-scripts "@maplelabs/maple-js@$VERSION" && break
+            if [ "$i" = "5" ]; then
+              echo "::error::@maplelabs/maple-js@$VERSION not installable from the registry"
+              exit 1
+            fi
+            sleep 15
+          done
+          ATTESTATION="$(npm view "@maplelabs/maple-js@$VERSION" dist.attestations.url || true)"
+          if [ -z "$ATTESTATION" ]; then
+            echo "::error::No provenance attestation attached to @maplelabs/maple-js@$VERSION"
+            exit 1
+          fi
+          npm audit signatures

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,26 +13,46 @@ on:
           - minor
           - major
 
-# Least-privilege defaults; the release job below grants only what it needs.
+# Least-privilege default; the release job below grants only what it needs.
 permissions: {}
 
 jobs:
   release-api:
     runs-on: ubuntu-latest
 
-    # Gate the deployment behind a GitHub Environment so it can carry
-    # protection rules (required reviewers, branch restrictions, secrets).
+    # Gate publishing behind a protected GitHub Environment. Configure a
+    # required reviewer (and branch restriction) on the `npm` environment in
+    # repo settings so every publish needs a manual approval.
     environment: npm
 
     permissions:
-      contents: write   # push the version bump commit/tag and create the release
+      contents: write   # create the GitHub release
       id-token: write   # mint the OIDC token for npm trusted publishing + provenance
 
     steps:
+      # Socket Firewall blocks installation of known-malicious packages by
+      # proxying the install. Added to the runner before any install runs.
+      - name: Set up Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1
+        with:
+          mode: firewall-free
+
+      # Short-lived, scoped GitHub App token replaces the long-lived PAT.
+      # The App must have contents:write on this repo and be added to any
+      # branch-protection bypass list so it can push the version-bump commit.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Ensures tags are also fetched
+          # Persist the App token so the push step below is authenticated by it.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -41,9 +61,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Enable corepack and install dependencies
+        # Install is routed through Socket Firewall (`sfw`).
         run: |
           corepack enable
-          yarn install
+          sfw yarn install
 
       - name: Build
         run: |
@@ -58,8 +79,10 @@ jobs:
           echo "NEW_VERSION=v$(node -p "require('./package.json').version")" >> $GITHUB_ENV
 
       - name: Publish to NPM
-        # No NPM_ACCESS_TOKEN: authentication is via OIDC trusted publishing,
-        # which also signs and attaches a provenance attestation.
+        # No NPM_ACCESS_TOKEN and no ~/.npmrc write: authentication is via OIDC
+        # trusted publishing, which also signs and attaches a provenance
+        # attestation. Configure the trusted publisher for @maplelabs/maple-js
+        # on npmjs.com (this repo + workflow + `npm` environment).
         run: |
           npm config set scope maplelabs
           npm publish --provenance --access=public
@@ -68,12 +91,12 @@ jobs:
         run: |
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           echo "Pushing changes to branch: $CURRENT_BRANCH"
-          # Uses the GITHUB_TOKEN credentials persisted by actions/checkout.
-          git push --force "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}" HEAD:$CURRENT_BRANCH --follow-tags
+          # Fast-forward push via the persisted App-token credentials; no --force.
+          git push --follow-tags origin HEAD:"$CURRENT_BRANCH"
 
       - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release create "$NEW_VERSION" \
           --repo="$GITHUB_REPOSITORY" \

--- a/package.json
+++ b/package.json
@@ -22,10 +22,6 @@
   "engines": {
     "node": ">=22"
   },
-  "publishConfig": {
-    "access": "public",
-    "provenance": true
-  },
   "scripts": {
     "dev": "rollup -c -w",
     "build": "rm -rf dist/ && rollup -c && cp -R src/abis dist/abis",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   "engines": {
     "node": ">=22"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "dev": "rollup -c -w",
     "build": "rm -rf dist/ && rollup -c && cp -R src/abis dist/abis",


### PR DESCRIPTION
## Summary

Moves `@maplelabs/maple-js` publishing to npm trusted publishing (OIDC) with provenance, and locks down the workflow that does it.

## Changes

**`release.yaml`: publish on GitHub Release**
- Triggers on `release: published` instead of `workflow_dispatch`; the publish job no longer writes to the repo (no push, no force-push, no long-lived token).
- Authenticates via OIDC trusted publishing: no `NPM_ACCESS_TOKEN`, no `~/.npmrc` and publishes with a provenance attestation so consumers can verify the package was built from this repo by CI.
- Gated behind the protected `npm` environment (required reviewer).
- Minimal permissions: `contents: read` + `id-token: write`, serialized via a concurrency group.
- Guards: the release tag must match the `package.json` version and point to a commit on `main`. Publishing a prerelease runs the full pipeline with `npm publish --dry-run` as a rehearsal.
- Dependency install goes through Socket Firewall with `yarn install --immutable` and publish runs with `--ignore-scripts`.
- Post-publish verification: installs the published version in a clean directory, asserts the provenance attestation is attached, and runs `npm audit signatures`.

**`ci.yaml`: new PR check**
- Install (via Socket Firewall), build, lint, and typecheck on every pull request.

**`package.json`**
- Adds `publishConfig` (`access: public`, `provenance: true`) so publish behavior is reviewable in-repo.

All actions are pinned to commit SHAs.

## Releasing after this change

1. Open a PR bumping the version (`npm version <type> --no-git-tag-version`) and merge it.
2. Create and publish a GitHub Release `v<version>` targeting `main`.
3. Approve the `npm` environment deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Established automated CI pipeline for build and lint verification.
  * Enhanced release process with version validation and provenance verification for published packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->