### PR TITLE
ci: pin corepack Yarn via packageManager integrity hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,5 @@
     "ws": "^7.5.10",
     "elliptic": "^6.6.1"
   },
-  "packageManager": "yarn@4.13.0"
+  "packageManager": "yarn@4.13.0+sha512.5c20ba010c99815433e5c8453112165e673f1c7948d8d2b267f4b5e52097538658388ebc9f9580656d9b75c5cc996f990f611f99304a2197d4c56d21eea370e7"
 }


### PR DESCRIPTION
packageManager now carries the sha512 integrity hash for yarn@4.13.0, so corepack verifies the release it downloads instead of trusting the registry (OFFP-486 / F8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned package manager version with integrity hash for enhanced reproducibility and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->