### PR TITLE
ci: Retry provenance verification to tolerate registry lag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,18 +92,20 @@ jobs:
           VERIFY_DIR="$RUNNER_TEMP/verify-publish"
           mkdir -p "$VERIFY_DIR" && cd "$VERIFY_DIR"
           npm init -y > /dev/null
-          # The registry can lag a few seconds behind a publish.
-          for i in 1 2 3 4 5; do
-            npm install --ignore-scripts "@maplelabs/maple-js@$VERSION" && break
-            if [ "$i" = "5" ]; then
-              echo "::error::@maplelabs/maple-js@$VERSION not installable from the registry"
+          # The registry lags a few seconds behind a publish, and the provenance
+          # attestation propagates slower than the tarball. Retry the whole path
+          # (install + attestation + audit) under one budget so neither lag fails
+          # an otherwise-good publish; only audit once the package installs.
+          for i in 1 2 3 4 5 6 7 8; do
+            if npm install --ignore-scripts "@maplelabs/maple-js@$VERSION"; then
+              ATTESTATION="$(npm view "@maplelabs/maple-js@$VERSION" dist.attestations.url || true)"
+              if [ -n "$ATTESTATION" ] && npm audit signatures; then
+                exit 0
+              fi
+            fi
+            if [ "$i" = "8" ]; then
+              echo "::error::@maplelabs/maple-js@$VERSION failed install/signature/provenance verification after retries"
               exit 1
             fi
             sleep 15
           done
-          ATTESTATION="$(npm view "@maplelabs/maple-js@$VERSION" dist.attestations.url || true)"
-          if [ -z "$ATTESTATION" ]; then
-            echo "::error::No provenance attestation attached to @maplelabs/maple-js@$VERSION"
-            exit 1
-          fi
-          npm audit signatures


### PR DESCRIPTION
| Type  | Ticket |
| :---: | :----: |
| Chore |  N/A   |

## Problem

The "Verify published package and provenance" step retries `npm install` for registry lag, but checks the attestation and runs `npm audit signatures` only once, immediately. The provenance attestation propagates slower than the tarball, so a successful publish can still fail verification with a 404 on the attestations endpoint. This is what flipped the v1.12.0 run to failure even though the package published correctly with verified provenance.

## Solution

Wrap the full verification — install, attestation presence, and `npm audit signatures` — in the retry loop, so a slow-propagating attestation no longer fails an otherwise-good publish. 8 attempts at 15s intervals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the post-publish verification process by consolidating provenance and signature checks into a single retry loop, increasing the number of attempts and ensuring the step only passes when attestation is available and signature verification succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->