### PR TITLE
docs: Add AGENTS.md and refresh SDK docs

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ yarn-error.log*
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Agent context — personal overrides
+AGENTS.local.md
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ yarn test                  # jest — integration tests that hit live contracts 
 
 ## Structure
 
-```
+```text
 src/
 ├── abis/        # Contract ABI JSON — source of truth, committed
 ├── addresses/   # Deployed addresses per project: {network}-{env}.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# maple-js
+
+TypeScript SDK for Maple Protocol's smart contracts. Ships contract ABIs, generated ethers v5 typings (typechain), and deployed addresses per network. Published to npm as `@maplelabs/maple-js` and consumed by Maple's offchain apps and bots.
+
+> **Convention**: `AGENTS.md` is canonical. Edit this file for repo context; `CLAUDE.md`, `.cursorrules`, and `GEMINI.md` all point here. See the workspace-level `AGENTS.md` for the full file convention used across Maple repos.
+
+## Stack
+
+- **Node** — version pinned in `.nvmrc` (enforced via `package.json` `engines`)
+- **Yarn 4** — run `corepack enable` to activate the pinned version
+- **TypeScript** strict mode
+- **ethers v5** + **typechain** for generated contract typings
+- **rollup** (build), **jest** (tests), **eslint** + **prettier**
+
+## Commands
+
+```bash
+corepack enable            # activate the pinned Yarn
+yarn install --immutable   # install dependencies
+yarn build-typechain       # generate src/typechain from src/abis (run before build)
+yarn build                 # rollup bundle -> dist/
+yarn lint                  # tsc --noEmit + eslint
+yarn format                # prettier --write
+yarn test                  # jest — integration tests that hit live contracts over RPC (not run in CI)
+```
+
+## Structure
+
+```
+src/
+├── abis/        # Contract ABI JSON — source of truth, committed
+├── addresses/   # Deployed addresses per project: {network}-{env}.ts
+├── helpers/     # Unsigned/signed transaction serialisation utils
+├── typechain/   # Generated ethers v5 typings — gitignored, built from abis/
+└── index.ts     # Public API — contract factories, addresses, utils
+scripts/build-typechain.js   # ABI -> typechain codegen
+config.json                  # typechain generation config
+```
+
+## Releasing
+
+See the [Releasing](README.md#releasing) section in the README.
+
+## Domain
+
+Smart-contract terms are **canonical** — never rename them in code (Pool not "vault", Pool Delegate not "manager", Lender/LP not "depositor", `requestRedeem`/`redeem` not "withdraw"). This SDK is the contract-facing layer, so names here must match the contracts exactly. The protocol's headline metric is **AUM** (not TVL).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To connect to a contract, you'll need its address and a signer. The `signer` sho
 **Connecting to a Contract Usage**
 
 ```js
-import { mapleGlobals } from '@maplelabs/maple-js'
+import { addresses, mapleGlobals } from '@maplelabs/maple-js'
 
 const contractAddress = addresses['mainnet-prod'].MapleToken
 const signer = 'yourSigner'
@@ -208,14 +208,14 @@ Releases publish to npm as `@maplelabs/maple-js` via [OIDC trusted publishing](h
 1. Bump `version` in `package.json` on a branch, then merge to `main`.
 2. Create a GitHub Release tagged `vX.Y.Z` (the tag must match `package.json`).
 3. The **Publish Release** workflow runs in the `npm` environment.
-4. A different Offchain dev approves the deployment.
+4. A different member of the `offchain` team approves the deployment.
 5. The package is published with `npm publish --provenance` (SLSA provenance); the workflow then re-installs the published version and verifies its attestation.
 
 The `npm` environment requires a `v*` tag, `offchain` team approval, prevent-self-review, and no admin bypass. Prereleases run a dry-run publish only.
 
 ## Additional Resources
 
-For technical infomration about Maple Protocol, visit: [our GitBook](https://maplefinance.gitbook.io/maple/technical-resources/protocol-overview).
+For technical information about Maple Protocol, visit: [our GitBook](https://maplefinance.gitbook.io/maple/technical-resources/protocol-overview).
 
 ## About Maple
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ A JavaScript SDK for interacting with Maple Protocol's smart contracts.
   - [Addresses](#addresses)
   - [Connecting to a Contract](#connecting-to-a-contract)
   - [Interacting with a Contract](#interacting-with-a-contract)
-- [Additional Resources](#additional-resources)
 - [Utils](#utils)
   - [Generating Unsigned Transaction Data](#generating-unsigned-transaction-data)
   - [Generating Signed Transaction Data](#generating-signed-transaction-data)
   - [Broadcasting Signed Transactions](#broadcasting-signed-transactions)
+- [Development](#development)
+- [Releasing](#releasing)
+- [Additional Resources](#additional-resources)
 
 ## Getting Started
 
@@ -33,21 +35,15 @@ yarn add @maplelabs/maple-js
 
 ### Addresses
 
-`maple-js` provides smart contract addresses for the following networks: `Ethereum Mainnet`, `Base Mainnet` & `Sepolia`.
-
-Valid network values are: `'mainnet' | 'sepolia' | 'base-mainnet'`.
-
-Valid project values are `'mainnet-prod' | 'mainnet-dev' | 'sepolia-dev' | 'base-mainnet-prod'`.
-
-Access addresses from the `addresses` object exported from `maple-js`. See a list of available contracts in `src/addresses/*.ts`.
+`maple-js` ships deployed contract addresses keyed by project. Valid projects are `'mainnet-prod' | 'mainnet-dev' | 'sepolia-prod' | 'sepolia-dev' | 'base-mainnet-prod'` (Base Mainnet is deprecated). See the available contracts per project in `src/addresses/*.ts`.
 
 **Addresses Usage**
 
 ```js
 import { addresses } from '@maplelabs/maple-js'
 
-// Returns the contract address for MapleToken on Ethereum Mainnet
-const contractAddress = addresses.mainnet.MapleToken
+// Returns the contract address for MapleToken on Ethereum Mainnet (prod)
+const contractAddress = addresses['mainnet-prod'].MapleToken
 ```
 
 ### Connecting to a Contract
@@ -59,7 +55,7 @@ To connect to a contract, you'll need its address and a signer. The `signer` sho
 ```js
 import { mapleGlobals } from '@maplelabs/maple-js'
 
-const contractAddress = addresses.mainnet.MapleToken
+const contractAddress = addresses['mainnet-prod'].MapleToken
 const signer = 'yourSigner'
 
 const contract = mapleGlobals.core.connect(contractAddress, signer)
@@ -189,6 +185,33 @@ This function sends the signed transaction to the network and returns the transa
 **Utils Example**
 
 An example usage of these utilities, including parameter setup and function calls, can be found in the repository at `src/helpers/serialiseExampleUse`.
+
+## Development
+
+Use the Node version pinned in `.nvmrc` (also enforced via `engines` in `package.json`); the repo uses Yarn 4 via corepack.
+
+```bash
+corepack enable            # activate the pinned Yarn
+yarn install --immutable   # install dependencies
+yarn build-typechain       # generate src/typechain from src/abis (run before build)
+yarn build                 # rollup bundle -> dist/
+yarn lint                  # tsc --noEmit + eslint
+yarn format                # prettier --write
+```
+
+`yarn test` runs the jest suites, which are integration tests that call live contracts over an RPC endpoint — they are not run in CI.
+
+## Releasing
+
+Releases publish to npm as `@maplelabs/maple-js` via [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers) — no long-lived npm tokens.
+
+1. Bump `version` in `package.json` on a branch, then merge to `main`.
+2. Create a GitHub Release tagged `vX.Y.Z` (the tag must match `package.json`).
+3. The **Publish Release** workflow runs in the `npm` environment.
+4. A different Offchain dev approves the deployment.
+5. The package is published with `npm publish --provenance` (SLSA provenance); the workflow then re-installs the published version and verifies its attestation.
+
+The `npm` environment requires a `v*` tag, `offchain` team approval, prevent-self-review, and no admin bypass. Prereleases run a dry-run publish only.
 
 ## Additional Resources
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "config.json"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=24.14.1"
   },
   "scripts": {
     "dev": "rollup -c -w",


### PR DESCRIPTION
| Type  | Ticket |
| :---: | :----: |
| Chore |  N/A   |

## Problem

`maple-js` had no agent/dev context files (unlike the rest of the workspace), and the README's address examples were stale — they used `addresses.mainnet.X`, but the exported `addresses` object is keyed by project, not network. `engines.node` also still said `>=22` while the rest of the stack has moved to Node 24.

## Solution

- Add `AGENTS.md` as canonical context per the Maple workspace convention, plus `CLAUDE.md` (`@AGENTS.md`) and `.cursorrules` / `GEMINI.md` symlinks; gitignore the `.local` variants.
- Refresh `README.md`: add **Development** and **Releasing** sections (the latter documents the npm OIDC trusted-publishing flow), fix the project-keyed address examples, add `sepolia-prod`, and note Base Mainnet is deprecated.
- Bump `engines.node` to `>=24.14.1` to match the stack: hub runs `node:24` in prod, every active `.nvmrc` pins `24.14.1`, and `maple-webapp` already declares `>=24.14.1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with revised table of contents plus new **Development** and **Releasing** sections (pinned tooling setup, build/test/lint/format commands, and a release workflow with trusted publishing and attestation verification).
  * Refreshed contract address docs to use project-keyed identifiers (e.g., `mainnet-prod`, `sepolia-dev`, `base-mainnet-prod` marked deprecated) and updated connection examples accordingly.

* **Chores**
  * Increased minimum supported Node.js version to **24.14.1**
  * Updated local override guidance references and ignore rules for personal context overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->