### PR TITLE
chore: Remove GEMINI.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 TypeScript SDK for Maple Protocol's smart contracts. Ships contract ABIs, generated ethers v5 typings (typechain), and deployed addresses per network. Published to npm as `@maplelabs/maple-js` and consumed by Maple's offchain apps and bots.
 
-> **Convention**: `AGENTS.md` is canonical. Edit this file for repo context; `CLAUDE.md`, `.cursorrules`, and `GEMINI.md` all point here. See the workspace-level `AGENTS.md` for the full file convention used across Maple repos.
+> **Convention**: `AGENTS.md` is canonical. Edit this file for repo context; `CLAUDE.md` and `.cursorrules` point here. See the workspace-level `AGENTS.md` for the full file convention used across Maple repos.
 
 ## Stack
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md


### PR DESCRIPTION
## Description

Removes the `GEMINI.md → AGENTS.md` symlink. All Gemini usage is via Antigravity now, which reads `AGENTS.md` natively and double-loads a sibling `GEMINI.md` as duplicate rule blocks; the classic Gemini CLI that keyed on the filename is retired.