### PR TITLE
chore: run build steps before npm test

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ yarn lint                  # tsc --noEmit + eslint
 yarn format                # prettier --write
 ```
 
-`yarn test` runs the jest suites, which are integration tests that call live contracts over an RPC endpoint — they are not run in CI.
+`yarn test` runs the jest suites, which are integration tests that call live contracts over an RPC endpoint — they are not run in CI. `npm test` runs `build-typechain` and `build` automatically via `pretest` before executing jest.
 
 ## Releasing
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "dev": "rollup -c -w",
+    "pretest": "npm run build-typechain && npm run build",
     "build": "rm -rf dist/ && rollup -c && cp -R src/abis dist/abis",
     "build-typechain": "node ./scripts/build-typechain.js",
     "test": "jest --collectCoverage",


### PR DESCRIPTION
## Summary
- Add `pretest` script to run `build-typechain` and `build` before jest
- Document automatic build behavior in README

## Test plan
- [x] Removed `dist/` and `src/typechain/`, then `npm test` regenerated artifacts via pretest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * `npm test` now automatically builds required artifacts before running Jest tests.
  * Development documentation now clarifies that integration tests use live contracts through an RPC endpoint and are not run in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->